### PR TITLE
Adds remote_src: yes to unarchive

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
   become: yes
   become_user: root
   unarchive:
-    copy: no
+    remote_src: yes
     src: /tmp/{{jruby_tgz}}
     dest: '{{jruby_install_parent_dir}}'
     creates: '{{jruby_install_dir}}'


### PR DESCRIPTION
Otherwise we get "Unable to find '/tmp/jruby-bin-9.1.12.0.tar.gz' in expected paths." (which is expected by the unarchive module)